### PR TITLE
New API end-point to pull all surveys including all statuses

### DIFF
--- a/PssNationalInstance/src/main/java/com/intellisoft/pssnationalinstance/controller/DataEntryController.java
+++ b/PssNationalInstance/src/main/java/com/intellisoft/pssnationalinstance/controller/DataEntryController.java
@@ -6,6 +6,7 @@ import com.intellisoft.pssnationalinstance.FormatterClass;
 import com.intellisoft.pssnationalinstance.Results;
 import com.intellisoft.pssnationalinstance.service_impl.service.DataEntryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -87,6 +88,21 @@ public class DataEntryController {
 //        Results results = dataEntryService.deleteDataEntry(id);
 //        return formatterClass.getResponse(results);
 //    }
+
+
+    /**
+     * verify/reject data entry
+     *
+     */
+    @PutMapping("/{id}/verify")
+    public ResponseEntity<Results> confirmDataEntry(@PathVariable Long id){
+        return ResponseEntity.status(HttpStatus.OK).body(dataEntryService.confirmDataEntry(id));
+    }
+
+    @PutMapping("/{id}/reject")
+    public ResponseEntity<Results> rejectDataEntry(@PathVariable Long id){
+        return ResponseEntity.status(HttpStatus.OK).body(dataEntryService.rejectDataEntry(id));
+    }
 
 
 }

--- a/PssNationalInstance/src/main/java/com/intellisoft/pssnationalinstance/controller/SurveyController.java
+++ b/PssNationalInstance/src/main/java/com/intellisoft/pssnationalinstance/controller/SurveyController.java
@@ -1,11 +1,11 @@
 package com.intellisoft.pssnationalinstance.controller;
 
 import com.intellisoft.pssnationalinstance.DbSurvey;
-import com.intellisoft.pssnationalinstance.DbVersions;
 import com.intellisoft.pssnationalinstance.FormatterClass;
 import com.intellisoft.pssnationalinstance.Results;
 import com.intellisoft.pssnationalinstance.service_impl.service.SurveysService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -69,6 +69,12 @@ public class SurveyController {
         return formatterClass.getResponse(results);
 
     }
+
+    @GetMapping(value = "/list-surveys")
+    public ResponseEntity<Results> listAllSurveys(@RequestParam(value = "status", required = false) String status) {
+        return ResponseEntity.status(HttpStatus.OK).body(surveysService.listAllSurveys( status));
+    }
+
     @PutMapping(value = "survey-details/{id}")
     public ResponseEntity<?> updateSurvey(
             @RequestBody DbSurvey dbSurvey,

--- a/PssNationalInstance/src/main/java/com/intellisoft/pssnationalinstance/controller/SurveyController.java
+++ b/PssNationalInstance/src/main/java/com/intellisoft/pssnationalinstance/controller/SurveyController.java
@@ -70,9 +70,9 @@ public class SurveyController {
 
     }
 
-    @GetMapping(value = "/list-surveys")
+    @GetMapping(value = "/list")
     public ResponseEntity<Results> listAllSurveys(@RequestParam(value = "status", required = false) String status) {
-        return ResponseEntity.status(HttpStatus.OK).body(surveysService.listAllSurveys( status));
+        return ResponseEntity.status(HttpStatus.OK).body(surveysService.listAdminSurveys(null, status));
     }
 
     @PutMapping(value = "survey-details/{id}")

--- a/PssNationalInstance/src/main/java/com/intellisoft/pssnationalinstance/service_impl/impl/DataEntryServiceImpl.java
+++ b/PssNationalInstance/src/main/java/com/intellisoft/pssnationalinstance/service_impl/impl/DataEntryServiceImpl.java
@@ -2,10 +2,7 @@ package com.intellisoft.pssnationalinstance.service_impl.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.intellisoft.pssnationalinstance.*;
-import com.intellisoft.pssnationalinstance.db.DataEntry;
-import com.intellisoft.pssnationalinstance.db.DataEntryResponses;
-import com.intellisoft.pssnationalinstance.db.PeriodConfiguration;
-import com.intellisoft.pssnationalinstance.db.Surveys;
+import com.intellisoft.pssnationalinstance.db.*;
 import com.intellisoft.pssnationalinstance.repository.DataEntryRepository;
 import com.intellisoft.pssnationalinstance.repository.DataEntryResponsesRepository;
 import com.intellisoft.pssnationalinstance.repository.SurveysRepo;
@@ -421,6 +418,47 @@ public class DataEntryServiceImpl implements DataEntryService {
         }
 
         return new Results(400, "Resource not found");
+    }
+
+    public Results confirmDataEntry(Long id) {
+
+        Optional<DataEntry> optionalDataEntries = dataEntryRepository.findById(id);
+
+        if (optionalDataEntries.isPresent()) {
+
+            DataEntry dataEntries = optionalDataEntries.get();
+
+            // change status to PUBLISHED
+            dataEntries.setStatus(PublishStatus.PUBLISHED.name());
+
+            //update on dB:
+            dataEntryRepository.save(dataEntries);
+
+            return new Results(200, dataEntries);
+        } else {
+            return new Results(400, "Resource not found, verification not successful");
+        }
+    }
+
+    @Override
+    public Results rejectDataEntry(Long id) {
+
+        Optional<DataEntry> optionalDataEntries = dataEntryRepository.findById(id);
+
+        if (optionalDataEntries.isPresent()) {
+
+            DataEntry dataEntries = optionalDataEntries.get();
+
+            // change status to REJECTED
+            dataEntries.setStatus(PublishStatus.REJECTED.name());
+
+            //update on dB:
+            dataEntryRepository.save(dataEntries);
+
+            return new Results(200, dataEntries);
+        } else {
+            return new Results(400, "Resource not found, rejection not successful");
+        }
     }
 
     private String getCommentsUploads(String codeComments, List<DbDataElements> dataElementsList) {

--- a/PssNationalInstance/src/main/java/com/intellisoft/pssnationalinstance/service_impl/service/DataEntryService.java
+++ b/PssNationalInstance/src/main/java/com/intellisoft/pssnationalinstance/service_impl/service/DataEntryService.java
@@ -17,4 +17,7 @@ public interface DataEntryService {
 
     Results updateDataEntry(String id, DbDataEntryData dbDataEntryData);
 
+    Results confirmDataEntry(Long id);
+
+    Results rejectDataEntry(Long id);
 }

--- a/PssNationalInstance/src/main/java/com/intellisoft/pssnationalinstance/service_impl/service/SurveysService.java
+++ b/PssNationalInstance/src/main/java/com/intellisoft/pssnationalinstance/service_impl/service/SurveysService.java
@@ -15,4 +15,5 @@ public interface SurveysService {
     Results updateSurvey(String surveyId, DbSurvey dbSurvey);
     Results updateSurvey(String surveyId);
 
+    Results listAllSurveys(String status);
 }

--- a/PssNationalInstance/src/main/java/com/intellisoft/pssnationalinstance/service_impl/service/SurveysService.java
+++ b/PssNationalInstance/src/main/java/com/intellisoft/pssnationalinstance/service_impl/service/SurveysService.java
@@ -14,6 +14,4 @@ public interface SurveysService {
     Results getSurveyDetails(String surveyId,Boolean respondents);
     Results updateSurvey(String surveyId, DbSurvey dbSurvey);
     Results updateSurvey(String surveyId);
-
-    Results listAllSurveys(String status);
 }

--- a/PssNationalInstance/src/main/kotlin/com/intellisoft/pssnationalinstance/DataClass.kt
+++ b/PssNationalInstance/src/main/kotlin/com/intellisoft/pssnationalinstance/DataClass.kt
@@ -208,7 +208,8 @@ enum class DhisStatus {
 enum class PublishStatus {
     DRAFT,
     PUBLISHED,
-    COMPLETED
+    COMPLETED,
+    REJECTED
 }
 enum class SurveySubmissionStatus {
     DRAFT, //Respondent has not sent responses


### PR DESCRIPTION
New API implementation on `{{local_url_national}}survey/list-surveys` to pull list of all surveys including the respondent details. Sample response:

`{
    "code": 200,
    "details": {
        "count": 87,
        "details": [
            {
                "surveyId": "1",
                "surveyName": "Test Survey",
                "surveyStatus": "SENT",
                "surveyDescription": "Survey Desc",
                "landingPage": "Long info",
                "respondentList": [
                    {
                        "respondentId": "1",
                        "emailAddress": "davidnjau21@gmail.com",
                        "createdAt": "2023-04-06 11:16:18.114",
                        "expiryDate": "2023-04-07 13:12:12",
                        "newLinkRequested": null
                    }
                ]
            },
            {
                "surveyId": "2",
                "surveyName": "Test Survey9",
                "surveyStatus": "SAVED",
                "surveyDescription": "Test Survey9",
                "landingPage": "Faucibus commodo massa rhoncus, volutpat. Dignissim sed eget risus enim. Mattis mauris semper sed amet vitae sed turpis id. Id dolor praesent donec est. Odio penatibus risus viverra tellus varius sit neque erat velit. Faucibus commodo massa rhoncus, volutpat. Dignissim sed eget risus enim. Mattis mauris semper sed amet vitae sed turpis id.",
                "respondentList": []
            }
        ]
    }
}
`