### PR TITLE
Update global dev-instance url on profile config & bug fix for non-nullable email field on notification subscription module

### DIFF
--- a/PssNationalInstance/src/main/kotlin/com/intellisoft/pssnationalinstance/DataClass.kt
+++ b/PssNationalInstance/src/main/kotlin/com/intellisoft/pssnationalinstance/DataClass.kt
@@ -11,7 +11,7 @@ data class DbResultsApi(@JsonProperty("code") val code: Int, @JsonProperty("deta
 
 data class UnsubscribeResponse(@JsonProperty("code") val code: Int, @JsonProperty("details") val details: NotificationSubscription)
 
-data class NotificationSubscription(@JsonProperty("id") val id: Long?, @JsonProperty("firstName") val firstName: String?, @JsonProperty("lastName") val lastName: String?, @JsonProperty("email") val email: String, @JsonProperty("phone") val phone: String?, @JsonProperty("isActive") val isActive: Boolean = true, @JsonProperty("userId") val userId: String?)
+data class NotificationSubscription(@JsonProperty("id") val id: Long?, @JsonProperty("firstName") val firstName: String?, @JsonProperty("lastName") val lastName: String?, @JsonProperty("email") val email: String?, @JsonProperty("phone") val phone: String?, @JsonProperty("isActive") val isActive: Boolean = true, @JsonProperty("userId") val userId: String?)
 
 data class DbResults(val count: Int, val details: Any?)
 

--- a/PssNationalInstance/src/main/resources/application-localdev.properties
+++ b/PssNationalInstance/src/main/resources/application-localdev.properties
@@ -2,7 +2,7 @@
 server-url=https://pssnational.intellisoftkenya.com
 
 #global dev-instance url
-dhis.international = https://pssnational.intellisoftkenya.com
+dhis.international = https://pssinternational.intellisoftkenya.com
 
 # Dhis Details
 dhis.username = admin


### PR DESCRIPTION
1. A small fix added to the global dev-instance url property which was picking the local instance url instead of the global url
2. Bug fix on notification module for non-nullable email field which was breaking the API call response.