### PR TITLE
Fix for IndexOutOfBoundsException in VersionEntityServiceImpl.listVersions

### DIFF
--- a/PssNationalInstance/src/main/java/com/intellisoft/pssnationalinstance/service_impl/impl/VersionEntityServiceImpl.java
+++ b/PssNationalInstance/src/main/java/com/intellisoft/pssnationalinstance/service_impl/impl/VersionEntityServiceImpl.java
@@ -179,7 +179,7 @@ public class VersionEntityServiceImpl implements VersionEntityService {
 
                         // Check if categoryId is present in savedIndicators
                         int index = savedIndicators.indexOf(categoryId);
-                        if (index != -1) {
+                        if (index != -1 && index < savedLatestList.size()) {
                             // categoryId is present in savedIndicators
                             boolean savedLatest = savedLatestList.get(index);
                             newIndicatorValueList.add(


### PR DESCRIPTION
Added a check to ensure the index is within the bounds of the `savedLatestList` before accessing it. This will prevent the `IndexOutOfBoundsException` when a `categoryId` is found in `savedIndicators` but the index is not valid in `savedLatestList`.